### PR TITLE
Fix nil assert in DatabaseConnection.connect(to:)

### DIFF
--- a/Sources/DatabaseKit/Connection/DatabaseConnection.swift
+++ b/Sources/DatabaseKit/Connection/DatabaseConnection.swift
@@ -18,7 +18,7 @@ public protocol DatabaseConnection: DatabaseConnectable {
 extension DatabaseConnection {
     /// See `DatabaseConnectable.connect(to:)`
     public func connect<D>(to database: DatabaseIdentifier<D>?) -> Future<D.Connection> {
-        assert(database == nil, "Unexpected \(#function): nil database identifier")
+        assert(database != nil, "Unexpected \(#function): nil database identifier")
         assert(self is D.Connection, "Unexpected \(#function): \(self) not \(D.Connection.self)")
         return Future(self as! D.Connection)
     }


### PR DESCRIPTION
If I'm reading this `assert` right, the `condition` should evaluate to `true`, which in this case means we're ensuring that the database is *not* `nil`.