### PR TITLE
remove connection config

### DIFF
--- a/Sources/DatabaseKit/Connection/DatabaseConnection.swift
+++ b/Sources/DatabaseKit/Connection/DatabaseConnection.swift
@@ -19,7 +19,8 @@ extension DatabaseConnection {
     /// See `DatabaseConnectable.connect(to:)`
     public func connect<D>(to database: DatabaseIdentifier<D>?) -> Future<D.Connection> {
         guard let conn = self as? D.Connection else {
-            fatalError("Unexpected \(#function): \(self) not \(D.Connection.self)")
+            let error = DatabaseKitError(identifier: "connectable", reason: "Unexpected \(#function): \(self) not \(D.Connection.self)")
+            return Future(error: error)
         }
         return Future(conn)
     }

--- a/Sources/DatabaseKit/Connection/DatabaseConnection.swift
+++ b/Sources/DatabaseKit/Connection/DatabaseConnection.swift
@@ -3,13 +3,6 @@ import Async
 /// Types conforming to this protocol can be used
 /// as a database connection for executing queries.
 public protocol DatabaseConnection: DatabaseConnectable {
-    associatedtype Config
-
-    /// This database's connection type.
-    /// The connection should also know which
-    /// type of database it belongs to.
-    // associatedtype Database: Fluent.Database
-
     /// Closes the database connection when finished.
     func close()
 }

--- a/Sources/DatabaseKit/Database/Database.swift
+++ b/Sources/DatabaseKit/Database/Database.swift
@@ -11,20 +11,13 @@ public protocol Database {
 
     /// Creates a new database connection that will
     /// execute callbacks on the supplied dispatch queue.
-    func makeConnection(
-        using config: Connection.Config,
-        on worker: Worker
-    ) -> Future<Connection>
+    func makeConnection(on worker: Worker) -> Future<Connection>
 }
 
 extension Database {
     /// Create a fluent connection pool for this database.
-    public func makeConnectionPool(
-        max: UInt,
-        using config: Connection.Config,
-        on worker: Worker
-    ) -> DatabaseConnectionPool<Self> {
-        return DatabaseConnectionPool(max: max, database: self, using: config, on: worker)
+    public func makeConnectionPool(max: UInt, on worker: Worker) -> DatabaseConnectionPool<Self> {
+        return DatabaseConnectionPool(max: max, database: self, on: worker)
     }
 }
 

--- a/Sources/DatabaseKit/DatabaseKitError.swift
+++ b/Sources/DatabaseKit/DatabaseKitError.swift
@@ -1,0 +1,41 @@
+import Debugging
+
+/// Errors that can be thrown while working with Vapor.
+public struct DatabaseKitError: Traceable, Debuggable, Swift.Error, Encodable, Helpable {
+    public static let readableName = "DatabaseKit Error"
+    public let identifier: String
+    public var reason: String
+    public var file: String
+    public var function: String
+    public var line: UInt
+    public var column: UInt
+    public var stackTrace: [String]
+    public var suggestedFixes: [String]
+    public var possibleCauses: [String]
+
+    init(
+        identifier: String,
+        reason: String,
+        file: String = #file,
+        function: String = #function,
+        line: UInt = #line,
+        column: UInt = #column,
+        suggestedFixes: [String] = [],
+        possibleCauses: [String] = []
+    ) {
+        self.identifier = identifier
+        self.reason = reason
+        self.file = file
+        self.function = function
+        self.line = line
+        self.column = column
+        self.stackTrace = DatabaseKitError.makeStackTrace()
+        self.suggestedFixes = suggestedFixes
+        self.possibleCauses = possibleCauses
+    }
+}
+
+/// For printing un-handleable errors.
+func ERROR(_ string: @autoclosure () -> String, file: StaticString = #file, line: Int = #line) {
+    print("[DatabaseKit] \(string()) [\(file.description.split(separator: "/").last!):\(line)]")
+}

--- a/Sources/DatabaseKit/Service/Container+CachedConnection.swift
+++ b/Sources/DatabaseKit/Service/Container+CachedConnection.swift
@@ -44,7 +44,11 @@ extension SubContainer {
         let conns = connections.cache
         connections.cache = [:]
         for (_, conn) in conns {
-            conn.release!()
+            guard let release = conn.release else {
+                ERROR("Release callback not set.")
+                continue
+            }
+            release()
         }
     }
 }

--- a/Sources/DatabaseKit/Service/Container+Connection.swift
+++ b/Sources/DatabaseKit/Service/Container+Connection.swift
@@ -33,13 +33,10 @@ extension Container {
             let databases = try self.make(Databases.self, for: Self.self)
 
             guard let db = databases.database(for: database) else {
-                fatalError("No database with id `\(database.uid)` is configured.")
+                throw DatabaseKitError(identifier: "requestConnection", reason: "No database with id `\(database.uid)` is configured.")
             }
 
-            return try db.makeConnection(
-                using: self.make(for: Database.Connection.self),
-                on: self
-            )
+            return db.makeConnection(on: self)
         }
     }
 

--- a/Sources/DatabaseKit/Service/DatabaseConnectionPoolCache.swift
+++ b/Sources/DatabaseKit/Service/DatabaseConnectionPoolCache.swift
@@ -1,3 +1,4 @@
+import Async
 import Service
 
 /// Caches database connection pools.
@@ -10,16 +11,16 @@ internal final class DatabaseConnectionPoolCache: Service {
     private var cache: [String: Any]
 
     /// The container to use.
-    private let container: Container
+    private let eventLoop: EventLoop
 
     /// Maximum connections.
     private let maxConnections: UInt
 
     /// Creates a new connection pool cache for the supplied
     /// databases using a given container.
-    internal init(databases: Databases, on container: Container, maxConnections: UInt) {
+    internal init(databases: Databases, maxConnections: UInt, on worker: Worker) {
         self.databases = databases
-        self.container = container
+        self.eventLoop = worker.eventLoop
         self.maxConnections = maxConnections
         self.cache = [:]
     }
@@ -32,13 +33,12 @@ internal final class DatabaseConnectionPoolCache: Service {
             return existing
         } else {
             guard let database = databases.database(for: id) else {
-                fatalError("no database")
+                throw DatabaseKitError(identifier: "requestPool", reason: "No database with id `\(id)` is configured.")
             }
 
-            let new = try database.makeConnectionPool(
+            let new = database.makeConnectionPool(
                 max: maxConnections,
-                using: container.make(for: D.Connection.self),
-                on: container
+                on: eventLoop
             )
             cache[id.uid] = new
             return new

--- a/Sources/DatabaseKit/Service/DatabaseConnectionPoolConfig.swift
+++ b/Sources/DatabaseKit/Service/DatabaseConnectionPoolConfig.swift
@@ -1,0 +1,29 @@
+import Service
+
+/// Configure the database connection pools.
+struct DatabaseConnectionPoolConfig: ServiceType {
+    /// Maximum number of connections per pool.
+    ///
+    /// There will normally be multiple connection pools in your application,
+    /// usually one per worker (where num workers = num logical CPU cores).
+    ///
+    /// The minimum supported value is `1`, meaning that your database must be able to handle
+    /// at least n connections where n = num logical CPU cores.
+    public var maxConnections: UInt
+
+    /// Creates a new `DatabaseConnectionPoolConfig`
+    public init(maxConnections: UInt) {
+        assert(maxConnections >= 1) // minimum supported value is 1
+        self.maxConnections = maxConnections
+    }
+
+    /// Creates a new `DatabaseConnectionPoolConfig` with default settings.
+    public static func `default`() -> DatabaseConnectionPoolConfig {
+        return .init(maxConnections: 2)
+    }
+
+    /// See `ServiceType.makeService(for:)`
+    static func makeService(for worker: Container) throws -> DatabaseConnectionPoolConfig {
+        return .default()
+    }
+}

--- a/Sources/DatabaseKit/Service/DatabaseKitProvider.swift
+++ b/Sources/DatabaseKit/Service/DatabaseKitProvider.swift
@@ -25,9 +25,10 @@ public final class DatabaseKitProvider: Provider {
         }
 
         services.register(isSingleton: true) { worker -> DatabaseConnectionPoolCache in
+            let config = try worker.make(DatabaseConnectionPoolConfig.self, for: DatabaseConnectionPoolCache.self)
             return try DatabaseConnectionPoolCache(
                 databases: worker.make(for: DatabaseConnectionPoolCache.self),
-                maxConnections: 2, // make this configurable
+                maxConnections: config.maxConnections,
                 on: worker.eventLoop
             )
         }
@@ -35,6 +36,8 @@ public final class DatabaseKitProvider: Provider {
         services.register(isSingleton: true) { worker -> ActiveDatabaseConnectionCache in
             return ActiveDatabaseConnectionCache()
         }
+
+        services.register(DatabaseConnectionPoolConfig.self)
     }
 
     /// See Provider.boot

--- a/Sources/DatabaseKit/Service/DatabaseKitProvider.swift
+++ b/Sources/DatabaseKit/Service/DatabaseKitProvider.swift
@@ -25,11 +25,10 @@ public final class DatabaseKitProvider: Provider {
         }
 
         services.register(isSingleton: true) { worker -> DatabaseConnectionPoolCache in
-            let container = worker as! SubContainer // must be subcontainer, or we will create a cycle
             return try DatabaseConnectionPoolCache(
                 databases: worker.make(for: DatabaseConnectionPoolCache.self),
-                on: container.superContainer,
-                maxConnections: 2 // make this configurable
+                maxConnections: 2, // make this configurable
+                on: worker.eventLoop
             )
         }
 


### PR DESCRIPTION
- [x] removes `ConnectionConfig` type, this can/should be configured via database alone
- [x] fixes bugs related to reference cycles on connection pool cache
- [x] adds a `DatabaseConnectionPoolConfig` for configuring connection pool size