### PR TITLE
Prevent `SQLSerializer` from accidentally creating all foreign keys twice

### DIFF
--- a/Sources/SQL/Serialization/SQLSerializer+SchemaQuery.swift
+++ b/Sources/SQL/Serialization/SQLSerializer+SchemaQuery.swift
@@ -11,7 +11,6 @@ extension SQLSerializer {
 
             let columns = query.addColumns.map { serialize(column: $0) }
                 + query.addForeignKeys.map { serialize(foreignKey: $0) }
-                + query.addForeignKeys.map { serialize(foreignKey: $0) }
             statement.append("(" + columns.joined(separator: ", ") + ")")
         case .alter:
             statement.append("ALTER TABLE")


### PR DESCRIPTION
This got added in https://github.com/vapor/database-kit/commit/b21128c50a47f6b3a852e0cbec490d5c6fd76df9, no idea why.