### PR TITLE
Fixing select for JOINs

### DIFF
--- a/Sources/SQL/Serialization/SQLSerializer+DataQuery.swift
+++ b/Sources/SQL/Serialization/SQLSerializer+DataQuery.swift
@@ -31,7 +31,7 @@ extension SQLSerializer {
             }
 
             if columns.isEmpty {
-                columns += ["*"] // ["\(table).*"]
+                columns += query.joins.isEmpty ? ["*"] : ["\(table).*"]
             } else {
                 columns += query.columns.map { serialize(column: $0) }
             }

--- a/Tests/SQLTests/DataTests.swift
+++ b/Tests/SQLTests/DataTests.swift
@@ -78,7 +78,7 @@ final class DataTests: XCTestCase {
 
         XCTAssertEqual(
             GeneralSQLSerializer.shared.serialize(data: select),
-            "SELECT * FROM `foo` JOIN `bar` ON `foo`.`id` = `bar`.`foo_id`"
+            "SELECT `foo`.* FROM `foo` JOIN `bar` ON `foo`.`id` = `bar`.`foo_id`"
         )
     }
 


### PR DESCRIPTION
When selecting with a JOIN table, just "*" doesn't do it as Fluent maps the id of JOIN table onto the target model

Super-simplified setup:
```swift
public final class Team: Model {
    public var id: UUID?
    public var name: String
    public var identifier: String
    public var admin: Bool
}

public final class User: Model {
    public var id: UUID?
    public var firstname: String
    public var lastname: String
    public var email: String
    public var verification: String?
    public var password: String?
    public var token: String?
    public var expires: Date?
    public var registered: Date
    public var disabled: Bool
    public var su: Bool
}

public final class TeamUser: ModifiablePivot, Model {
    
    public typealias Left = Team
    public typealias Right = User
    
    public static var leftIDKey: WritableKeyPath<TeamUser, UUID > {
        return \.teamId
    }
    
    public static var rightIDKey: WritableKeyPath<TeamUser, UUID > {
        return \.userId
    }
    
    public static var idKey: WritableKeyPath<TeamUser, UUID?> {
        return \.id
    }
    
    public var id: UUID?
    public var teamId: UUID
    public var userId: UUID
    
    // MARK: Initialization
    
    public init(_ left: TeamUser.Left, _ right: TeamUser.Right) throws {
        teamId = try left.requireID()
        userId = try right.requireID()
    }
    
}

extension User {
    
    public var teams: Siblings<User, Team, TeamUser> {
        return siblings()
    }
    
}

```

When I do `user.teams.query(on: req).all()` the teams I get back have id's on the `team+user.id` table ...