### PR TITLE
Dbc extendable

### DIFF
--- a/Sources/DatabaseKit/Connection/DatabaseConnection.swift
+++ b/Sources/DatabaseKit/Connection/DatabaseConnection.swift
@@ -1,12 +1,12 @@
 import Async
+import Service
 
 /// Types conforming to this protocol can be used
 /// as a database connection for executing queries.
-public protocol DatabaseConnection: DatabaseConnectable {
+public protocol DatabaseConnection: DatabaseConnectable, Extendable {
     /// Closes the database connection when finished.
     func close()
 }
-
 
 extension DatabaseConnection {
     /// See `DatabaseConnectable.connect(to:)`
@@ -23,3 +23,47 @@ extension DatabaseConnection {
         }
     }
 }
+
+/// MARK: Deprecated
+
+extension DatabaseConnection {
+    @available(*, deprecated, message: "Implement on `DatabaseConnection` instead.")
+    public var extend: Extend {
+        get {
+            let cache: ExtendCache
+            if let existing = extendCache.currentValue {
+                cache = existing
+            } else {
+                cache = .init()
+                extendCache.currentValue = cache
+            }
+
+            let extend: Extend
+            if let existing = cache.storage[.init(self)] {
+                extend = existing
+            } else {
+                extend = .init()
+                cache.storage[.init(self)] = extend
+            }
+
+            return extend
+        }
+        set {
+            let cache: ExtendCache
+            if let existing = extendCache.currentValue {
+                cache = existing
+            } else {
+                cache = .init()
+                extendCache.currentValue = cache
+            }
+            cache.storage[.init(self)] = newValue
+        }
+    }
+}
+
+fileprivate final class ExtendCache {
+    var storage: [ObjectIdentifier: Extend]
+    init() { storage = [:] }
+}
+
+fileprivate var extendCache: ThreadSpecificVariable<ExtendCache> = .init()


### PR DESCRIPTION
- [x] requires `DatabaseConnection` be `Extendable`. This will allow higher-level libraries to store things on a connection without resorting to global caches which may leak memory.