### PR TITLE
fixing custom columns bug

### DIFF
--- a/Sources/SQL/Serialization/SQLSerializer+DataQuery.swift
+++ b/Sources/SQL/Serialization/SQLSerializer+DataQuery.swift
@@ -24,16 +24,14 @@ extension SQLSerializer {
                 statement.append("DISTINCT")
             }
 
-            var columns: [String] = []
+            var columns: [String] = query.columns.map { serialize(column: $0) }
 
             if !query.computed.isEmpty {
                 columns += query.computed.map { serialize(computed: $0) }
             }
 
             if columns.isEmpty {
-                columns += ["*"] // ["\(table).*"]
-            } else {
-                columns += query.columns.map { serialize(column: $0) }
+                columns += ["*"]
             }
 
             statement.append(columns.joined(separator: ", "))

--- a/Tests/SQLTests/DataTests.swift
+++ b/Tests/SQLTests/DataTests.swift
@@ -10,6 +10,19 @@ final class DataTests: XCTestCase {
         )
     }
 
+    func testCustomColumnSelect() {
+        let select = DataQuery(statement: .select, table: "foo", columns: [
+            DataColumn(table: "foo", name: "d"),
+            DataColumn(table: "foo", name: "l")
+            ]
+        )
+        
+        XCTAssertEqual(
+            GeneralSQLSerializer.shared.serialize(data: select),
+            "SELECT `foo`.`d`, `foo`.`l` FROM `foo`"
+        )
+    }
+    
     func testSelectWithPredicates() {
         var select = DataQuery(statement: .select, table: "foo")
 


### PR DESCRIPTION
there was no way to specify columns before

the customQuery is quite incomplete without custom columns

the GROUP BY also works only with aggregated methods … I have only tested that back when I was adding it
just found out few days ago you can’t do GROUP BY if you don’t select the columns you grouping by apparently … at least on PSQL