### PR TITLE
Add CacheKit as an exported library target.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,6 +6,7 @@ let package = Package(
     products: [
         .library(name: "DatabaseKit", targets: ["DatabaseKit"]),
         .library(name: "SQL", targets: ["SQL"]),
+        .library(name: "CacheKit", targets: ["CacheKit"]),
     ],
     dependencies: [
         // 🌎 Utility package containing tools for byte manipulation, Codable, OS APIs, and debugging.


### PR DESCRIPTION
This is required to build Fluent's `FluentCache.swift` after b674c2c8804aa3a698e647b38843cfcd43e83a2b, also see https://github.com/vapor/fluent/pull/458.

/cc @pedantix 