### PR TITLE
Support set connectionPoolMaxConnections when add database to the databases

### DIFF
--- a/Sources/DatabaseKit/ConnectionPool/DatabaseConnectionPoolCache.swift
+++ b/Sources/DatabaseKit/ConnectionPool/DatabaseConnectionPoolCache.swift
@@ -31,7 +31,12 @@ internal final class DatabaseConnectionPoolCache: ServiceType {
         if let existing = cache[dbid.uid] as? DatabaseConnectionPool<ConfiguredDatabase<D>> {
             return existing
         } else {
-            let new = try databases.requireDatabase(for: dbid).newConnectionPool(config: config, on: eventLoop)
+            var _config = config
+            if let poolSize = databases.poolSize(for: dbid) {
+                _config.maxConnections = poolSize
+            }
+
+            let new = try databases.requireDatabase(for: dbid).newConnectionPool(config: _config, on: eventLoop)
             cache[dbid.uid] = new
             return new
         }

--- a/Sources/DatabaseKit/ConnectionPool/DatabaseConnectionPoolCache.swift
+++ b/Sources/DatabaseKit/ConnectionPool/DatabaseConnectionPoolCache.swift
@@ -32,8 +32,8 @@ internal final class DatabaseConnectionPoolCache: ServiceType {
             return existing
         } else {
             var _config = config
-            if let poolSize = databases.poolSize(for: dbid) {
-                _config.maxConnections = poolSize
+            if let connectionPoolMaxConnections = databases.connectionPoolMaxConnections(for: dbid) {
+                _config.maxConnections = connectionPoolMaxConnections
             }
 
             let new = try databases.requireDatabase(for: dbid).newConnectionPool(config: _config, on: eventLoop)

--- a/Sources/DatabaseKit/Database/DatabaseConfig.swift
+++ b/Sources/DatabaseKit/Database/DatabaseConfig.swift
@@ -6,14 +6,14 @@ public struct DatabasesConfig: Service {
     /// Array of connection configuration.
     private var connectionConfig: [String: Any]
 
-    /// Array of poolSize configuration.
-    private var poolSizeConfig: [String: Int]
+    /// Array of connectionPoolMaxConnections configuration.
+    private var connectionPoolMaxConnectionsConfig: [String: Int]
 
     /// Create a new database config helper.
     public init() {
         self.lazyDatabases = [:]
         self.connectionConfig = [:]
-        self.poolSizeConfig = [:]
+        self.connectionPoolMaxConnectionsConfig = [:]
     }
 
     // MARK: Database
@@ -26,12 +26,12 @@ public struct DatabasesConfig: Service {
     /// - parameters:
     ///     - database: Initialized instance of a `Database` to add.
     ///     - id: `DatabaseIdentifier` to use for this `Database`.
-    public mutating func add<D>(database: D, as id: DatabaseIdentifier<D>, poolSize: Int? = nil) {
+    public mutating func add<D>(database: D, as id: DatabaseIdentifier<D>, connectionPoolMaxConnections: Int? = nil) {
         assert(lazyDatabases[id.uid] == nil, "A database with id '\(id.uid)' is already registered.")
         lazyDatabases[id.uid] = { _ in database }
-        if let poolSize = poolSize {
-            assert(poolSize >= 1)
-            poolSizeConfig[id.uid] = poolSize
+        if let connectionPoolMaxConnections = connectionPoolMaxConnections {
+            assert(connectionPoolMaxConnections >= 1)
+            connectionPoolMaxConnectionsConfig[id.uid] = connectionPoolMaxConnections
         }
     }
 
@@ -44,12 +44,12 @@ public struct DatabasesConfig: Service {
     /// - parameters:
     ///     - database: Type of a `Database` to add.
     ///     - id: `DatabaseIdentifier` to use for this `Database`.
-    public mutating func add<D>(database: D.Type, as id: DatabaseIdentifier<D>, poolSize: Int? = nil) {
+    public mutating func add<D>(database: D.Type, as id: DatabaseIdentifier<D>, connectionPoolMaxConnections: Int? = nil) {
         assert(lazyDatabases[id.uid] == nil, "A database with id '\(id.uid)' is already registered.")
         lazyDatabases[id.uid] = { try $0.make(D.self) }
-        if let poolSize = poolSize {
-            assert(poolSize >= 1)
-            poolSizeConfig[id.uid] = poolSize
+        if let connectionPoolMaxConnections = connectionPoolMaxConnections {
+            assert(connectionPoolMaxConnections >= 1)
+            connectionPoolMaxConnectionsConfig[id.uid] = connectionPoolMaxConnections
         }
     }
 
@@ -62,12 +62,12 @@ public struct DatabasesConfig: Service {
     /// - parameters:
     ///     - id: `DatabaseIdentifier` to use for this `Database`.
     ///     - database: Closure accepting a `Container` and returning a `Database`.
-    public mutating func add<D>(as id: DatabaseIdentifier<D>, poolSize: Int? = nil, database: @escaping (Container) throws -> D) {
+    public mutating func add<D>(as id: DatabaseIdentifier<D>, connectionPoolMaxConnections: Int? = nil, database: @escaping (Container) throws -> D) {
         assert(lazyDatabases[id.uid] == nil, "A database with id '\(id.uid)' is already registered.")
         lazyDatabases[id.uid] = database
-        if let poolSize = poolSize {
-            assert(poolSize >= 1)
-            poolSizeConfig[id.uid] = poolSize
+        if let connectionPoolMaxConnections = connectionPoolMaxConnections {
+            assert(connectionPoolMaxConnections >= 1)
+            connectionPoolMaxConnectionsConfig[id.uid] = connectionPoolMaxConnections
         }
     }
 
@@ -118,6 +118,6 @@ public struct DatabasesConfig: Service {
         for (id, lazyDatabase) in lazyDatabases {
             databases[id] = try lazyDatabase(container)
         }
-        return Databases(storage: databases, connectionConfig: connectionConfig, poolSizeConfig: poolSizeConfig)
+        return Databases(storage: databases, connectionConfig: connectionConfig, connectionPoolMaxConnectionsConfig: connectionPoolMaxConnectionsConfig)
     }
 }

--- a/Sources/DatabaseKit/Database/DatabaseConfig.swift
+++ b/Sources/DatabaseKit/Database/DatabaseConfig.swift
@@ -26,13 +26,9 @@ public struct DatabasesConfig: Service {
     /// - parameters:
     ///     - database: Initialized instance of a `Database` to add.
     ///     - id: `DatabaseIdentifier` to use for this `Database`.
-    public mutating func add<D>(database: D, as id: DatabaseIdentifier<D>, connectionPoolMaxConnections: Int? = nil) {
+    public mutating func add<D>(database: D, as id: DatabaseIdentifier<D>) {
         assert(lazyDatabases[id.uid] == nil, "A database with id '\(id.uid)' is already registered.")
         lazyDatabases[id.uid] = { _ in database }
-        if let connectionPoolMaxConnections = connectionPoolMaxConnections {
-            assert(connectionPoolMaxConnections >= 1)
-            connectionPoolMaxConnectionsConfig[id.uid] = connectionPoolMaxConnections
-        }
     }
 
 
@@ -44,13 +40,9 @@ public struct DatabasesConfig: Service {
     /// - parameters:
     ///     - database: Type of a `Database` to add.
     ///     - id: `DatabaseIdentifier` to use for this `Database`.
-    public mutating func add<D>(database: D.Type, as id: DatabaseIdentifier<D>, connectionPoolMaxConnections: Int? = nil) {
+    public mutating func add<D>(database: D.Type, as id: DatabaseIdentifier<D>) {
         assert(lazyDatabases[id.uid] == nil, "A database with id '\(id.uid)' is already registered.")
         lazyDatabases[id.uid] = { try $0.make(D.self) }
-        if let connectionPoolMaxConnections = connectionPoolMaxConnections {
-            assert(connectionPoolMaxConnections >= 1)
-            connectionPoolMaxConnectionsConfig[id.uid] = connectionPoolMaxConnections
-        }
     }
 
     /// Add a lazy database to the config. This closure will be run when the application boots.
@@ -62,13 +54,22 @@ public struct DatabasesConfig: Service {
     /// - parameters:
     ///     - id: `DatabaseIdentifier` to use for this `Database`.
     ///     - database: Closure accepting a `Container` and returning a `Database`.
-    public mutating func add<D>(as id: DatabaseIdentifier<D>, connectionPoolMaxConnections: Int? = nil, database: @escaping (Container) throws -> D) {
+    public mutating func add<D>(as id: DatabaseIdentifier<D>, database: @escaping (Container) throws -> D) {
         assert(lazyDatabases[id.uid] == nil, "A database with id '\(id.uid)' is already registered.")
         lazyDatabases[id.uid] = database
-        if let connectionPoolMaxConnections = connectionPoolMaxConnections {
-            assert(connectionPoolMaxConnections >= 1)
-            connectionPoolMaxConnectionsConfig[id.uid] = connectionPoolMaxConnections
-        }
+    }
+
+    // MARK: ConnectionPoolMaxConnections
+    /// Add database connectionPoolMaxConnections to the config
+    ///
+    ///     databases.connectionPoolMaxConnections(1, for: .psql)
+    ///
+    /// - parameters:
+    ///     - maxConnections: maxConnections for `DatabaseIdentifier`.
+    ///     - id: `DatabaseIdentifier` to use for this `Database`.
+    public mutating func connectionPoolMaxConnections<D>(_ maxConnections: Int, for id: DatabaseIdentifier<D>) {
+        assert(maxConnections >= 1)
+        connectionPoolMaxConnectionsConfig[id.uid] = maxConnections
     }
 
     // MARK: Logging

--- a/Sources/DatabaseKit/Database/Databases.swift
+++ b/Sources/DatabaseKit/Database/Databases.swift
@@ -11,10 +11,14 @@ public struct Databases: ServiceType {
     /// Private storage: `[DatabaseIdentifier: ConnectionConfig]`
     private let connectionConfig: [String: Any]
 
+    /// Private storage: `[DatabaseIdentifier: Int]`
+    private let poolSizeConfig: [String: Int]
+
     /// Private init: creates a new `Databases` struct.
-    internal init(storage: [String: Any], connectionConfig: [String: Any]) {
+    internal init(storage: [String: Any], connectionConfig: [String: Any], poolSizeConfig: [String: Int]) {
         self.storage = storage
         self.connectionConfig = connectionConfig
+        self.poolSizeConfig = poolSizeConfig
     }
 
     /// Fetches the `Database` for a given `DatabaseIdentifier`.
@@ -46,4 +50,19 @@ public struct Databases: ServiceType {
         let config = connectionConfig[dbid.uid] as? ConnectionConfig<D> ?? .init()
         return ConfiguredDatabase(config: config, base: db)
     }
+
+    /// Fetches the `poolSize` for a given `DatabaseIdentifier`.
+    ///
+    ///     let poolSize = databases.poolSize(for: .psql)
+    ///
+    /// - parameters:
+    ///     - id: `DatabaseIdentifier` of the `Database` to fetch.
+    /// - returns: poolSize by the supplied ID, if one could be found.
+    public func poolSize<D>(for dbid: DatabaseIdentifier<D>) -> Int? {
+        guard let size = poolSizeConfig[dbid.uid] else {
+            return nil
+        }
+        return size
+    }
+
 }

--- a/Sources/DatabaseKit/Database/Databases.swift
+++ b/Sources/DatabaseKit/Database/Databases.swift
@@ -12,13 +12,13 @@ public struct Databases: ServiceType {
     private let connectionConfig: [String: Any]
 
     /// Private storage: `[DatabaseIdentifier: Int]`
-    private let poolSizeConfig: [String: Int]
+    private let connectionPoolMaxConnectionsConfig: [String: Int]
 
     /// Private init: creates a new `Databases` struct.
-    internal init(storage: [String: Any], connectionConfig: [String: Any], poolSizeConfig: [String: Int]) {
+    internal init(storage: [String: Any], connectionConfig: [String: Any], connectionPoolMaxConnectionsConfig: [String: Int]) {
         self.storage = storage
         self.connectionConfig = connectionConfig
-        self.poolSizeConfig = poolSizeConfig
+        self.connectionPoolMaxConnectionsConfig = connectionPoolMaxConnectionsConfig
     }
 
     /// Fetches the `Database` for a given `DatabaseIdentifier`.
@@ -51,18 +51,18 @@ public struct Databases: ServiceType {
         return ConfiguredDatabase(config: config, base: db)
     }
 
-    /// Fetches the `poolSize` for a given `DatabaseIdentifier`.
+    /// Fetches the `connectionPoolMaxConnections` for a given `DatabaseIdentifier`.
     ///
-    ///     let poolSize = databases.poolSize(for: .psql)
+    ///     let connectionPoolMaxConnections = databases.connectionPoolMaxConnections(for: .psql)
     ///
     /// - parameters:
     ///     - id: `DatabaseIdentifier` of the `Database` to fetch.
-    /// - returns: poolSize by the supplied ID, if one could be found.
-    public func poolSize<D>(for dbid: DatabaseIdentifier<D>) -> Int? {
-        guard let size = poolSizeConfig[dbid.uid] else {
+    /// - returns: connectionPool maxConnections by the supplied ID, if one could be found.
+    public func connectionPoolMaxConnections<D>(for dbid: DatabaseIdentifier<D>) -> Int? {
+        guard let maxConnections = connectionPoolMaxConnectionsConfig[dbid.uid] else {
             return nil
         }
-        return size
+        return maxConnections
     }
 
 }


### PR DESCRIPTION
The default connectionPool maxConnections equals system core size, but we want to custom it.

```swift
let redisConfig = RedisClientConfig(url: URL(string: "redis://127.0.0.1:6379")!)
let redis = try RedisDatabase(config: redisConfig)

let psqlConfig = try PostgreSQLDatabaseConfig.default()
let psql = PostgreSQLDatabase(config: psqlConfig)

var databases = DatabasesConfig()
databases.add(database: psql, as: .psql)
databases.connectionPoolMaxConnections(10, for: .psql)
databases.add(database: redis, as: .redis)
databases.connectionPoolMaxConnections(5, for: .redis)
services.register(databases)
```
