### PR TITLE
change default max conns per pool

### DIFF
--- a/Sources/DatabaseKit/ConnectionPool/DatabaseConnectionPoolConfig.swift
+++ b/Sources/DatabaseKit/ConnectionPool/DatabaseConnectionPoolConfig.swift
@@ -2,7 +2,7 @@
 public struct DatabaseConnectionPoolConfig: ServiceType {
     /// Creates a new `DatabaseConnectionPoolConfig` with default settings.
     public static func `default`() -> DatabaseConnectionPoolConfig {
-        return .init(maxConnections: System.coreCount)
+        return .init(maxConnections: 10)
     }
 
     /// See `ServiceType`.

--- a/circle.yml
+++ b/circle.yml
@@ -110,7 +110,7 @@ jobs:
     docker:
       - image: codevapor/swift:4.1
       - image: circleci/postgres:latest
-        name: psql-cleartext
+        name: psql
         environment:
           POSTGRES_USER: vapor_username
           POSTGRES_DB: vapor_database


### PR DESCRIPTION
Changes the default max connections per pool to `10`. This was previously `System.coreCount` which can create issues on systems with only one core as some complex Vapor routes require 2 connections at once to run successfully. 

Fixes #45.