### PR TITLE
Use a fixed default connection pool size

### DIFF
--- a/Sources/DatabaseKit/ConnectionPool/DatabaseConnectionPoolConfig.swift
+++ b/Sources/DatabaseKit/ConnectionPool/DatabaseConnectionPoolConfig.swift
@@ -2,7 +2,7 @@
 public struct DatabaseConnectionPoolConfig: ServiceType {
     /// Creates a new `DatabaseConnectionPoolConfig` with default settings.
     public static func `default`() -> DatabaseConnectionPoolConfig {
-        return .init(maxConnections: System.coreCount)
+        return .init(maxConnections: 2)
     }
 
     /// See `ServiceType`.


### PR DESCRIPTION
See https://github.com/vapor/fluent/issues/564#issuecomment-416194623 for discussion. Open to changing the exact value of the constant.