### PR TITLE
Fix pool actives append error when NIO.NIOConnectionError happened

### DIFF
--- a/Sources/DatabaseKit/Connection/Container+NewConnection.swift
+++ b/Sources/DatabaseKit/Connection/Container+NewConnection.swift
@@ -19,8 +19,12 @@ extension Container {
     /// - returns: A future containing the result of the closure.
     public func withNewConnection<Database, T>(to dbid: DatabaseIdentifier<Database>, closure: @escaping (Database.Connection) throws -> Future<T>) -> Future<T> {
         return newConnection(to: dbid).flatMap(to: T.self) { conn in
-            return try closure(conn).always {
+            do {
+                return try closure(conn).always { conn.close() }
+            } catch {
                 conn.close()
+                
+                throw error
             }
         }
     }


### PR DESCRIPTION
Hi,

I restart redis server after app startup, then all actives are unavailable and no connection.

Because NIO.NIOConnectionError will happened when call database.newConnection.

